### PR TITLE
Add Chrome extension PoC to highlight full-width brackets in Slack sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# slack-chrome-extension
+# Slack Bracket Highlighter (Chrome Extension)
+
+Highlights text wrapped in full-width brackets (e.g. `【...】`) inside the Slack web
+client sidebar.
+
+## Install (local)
+
+1. Open `chrome://extensions` and enable **Developer mode**.
+2. Click **Load unpacked** and select this repository folder.
+3. Open Slack in the browser and confirm the sidebar highlight appears.
+
+## Options
+
+Open the extension options page to:
+- Enable or disable highlighting.
+- Customize the highlight color.
+
+## Notes
+
+- Targets the Slack web client (`https://*.slack.com/*`).
+- Uses a content script with a `MutationObserver` to handle dynamic updates.
+- No data is sent externally; settings are stored in Chrome sync storage.

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,0 +1,158 @@
+const DEFAULT_SETTINGS = {
+  enabled: true,
+  highlightColor: "#fff3a3"
+};
+
+const HIGHLIGHT_CLASS = "slack-bracket-highlight";
+const HIGHLIGHT_ATTR = "data-slack-bracket-highlight";
+const ROOT_SELECTORS = [
+  '[data-qa="sidebar"]',
+  '[data-qa="channel_sidebar"]',
+  '[data-qa="sidebar_content"]',
+  '[data-qa="sidebar_sections"]',
+  'nav[aria-label="Slack sidebar"]',
+  'nav[aria-label="Navigation"]'
+];
+
+let currentSettings = { ...DEFAULT_SETTINGS };
+let observer;
+let mutationTimeout;
+
+function getSidebarRoots() {
+  const roots = ROOT_SELECTORS.flatMap((selector) =>
+    Array.from(document.querySelectorAll(selector))
+  );
+
+  if (roots.length > 0) {
+    return roots;
+  }
+
+  const fallback = document.querySelector("#client-ui nav");
+  return fallback ? [fallback] : [];
+}
+
+function setHighlightColor(color) {
+  document.documentElement.style.setProperty(
+    "--slack-bracket-highlight-color",
+    color
+  );
+}
+
+function unwrapHighlights(root) {
+  const highlights = root.querySelectorAll(`.${HIGHLIGHT_CLASS}`);
+  highlights.forEach((highlight) => {
+    const parent = highlight.parentNode;
+    if (!parent) return;
+    parent.replaceChild(document.createTextNode(highlight.textContent), highlight);
+    parent.normalize();
+  });
+}
+
+function shouldProcessTextNode(node) {
+  if (!node || !node.parentElement) return false;
+  if (node.parentElement.closest(`.${HIGHLIGHT_CLASS}`)) return false;
+  if (!node.textContent || !node.textContent.includes("【")) return false;
+  return true;
+}
+
+function wrapBracketTextNode(node) {
+  const text = node.textContent;
+  const regex = /【([^】]+)】/g;
+  let match;
+  let lastIndex = 0;
+  const fragment = document.createDocumentFragment();
+
+  while ((match = regex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      fragment.appendChild(
+        document.createTextNode(text.slice(lastIndex, match.index))
+      );
+    }
+
+    const span = document.createElement("span");
+    span.className = HIGHLIGHT_CLASS;
+    span.setAttribute(HIGHLIGHT_ATTR, "true");
+    span.textContent = `【${match[1]}】`;
+    fragment.appendChild(span);
+
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    fragment.appendChild(document.createTextNode(text.slice(lastIndex)));
+  }
+
+  node.parentNode.replaceChild(fragment, node);
+}
+
+function highlightBrackets(root) {
+  const walker = document.createTreeWalker(
+    root,
+    NodeFilter.SHOW_TEXT,
+    {
+      acceptNode(node) {
+        if (!shouldProcessTextNode(node)) return NodeFilter.FILTER_REJECT;
+        return NodeFilter.FILTER_ACCEPT;
+      }
+    }
+  );
+
+  const nodes = [];
+  let current;
+  while ((current = walker.nextNode())) {
+    nodes.push(current);
+  }
+
+  nodes.forEach(wrapBracketTextNode);
+}
+
+function refreshHighlights() {
+  const roots = getSidebarRoots();
+  if (roots.length === 0) return;
+
+  roots.forEach((root) => {
+    unwrapHighlights(root);
+    if (currentSettings.enabled) {
+      highlightBrackets(root);
+    }
+  });
+}
+
+function scheduleRefresh() {
+  if (mutationTimeout) {
+    window.clearTimeout(mutationTimeout);
+  }
+
+  mutationTimeout = window.setTimeout(refreshHighlights, 150);
+}
+
+function startObserver() {
+  if (observer) {
+    observer.disconnect();
+  }
+
+  observer = new MutationObserver(scheduleRefresh);
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+    characterData: true
+  });
+}
+
+function applySettings(settings) {
+  currentSettings = { ...DEFAULT_SETTINGS, ...settings };
+  setHighlightColor(currentSettings.highlightColor);
+  refreshHighlights();
+}
+
+chrome.storage.sync.get(DEFAULT_SETTINGS, applySettings);
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area !== "sync") return;
+  const updated = { ...currentSettings };
+  Object.keys(changes).forEach((key) => {
+    updated[key] = changes[key].newValue;
+  });
+  applySettings(updated);
+});
+
+startObserver();

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,17 @@
+{
+  "manifest_version": 3,
+  "name": "Slack Bracket Highlighter",
+  "version": "0.1.0",
+  "description": "Highlight text inside full-width brackets in Slack sidebar section names.",
+  "permissions": ["storage"],
+  "host_permissions": ["https://*.slack.com/*"],
+  "options_page": "options.html",
+  "content_scripts": [
+    {
+      "matches": ["https://*.slack.com/*"],
+      "js": ["contentScript.js"],
+      "css": ["styles.css"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/options.css
+++ b/options.css
@@ -1,0 +1,57 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background: #f7f8fa;
+  color: #1d1c1d;
+}
+
+body {
+  margin: 0;
+  padding: 32px;
+}
+
+.options-card {
+  max-width: 520px;
+  margin: 0 auto;
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 24px 28px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);
+  border: 1px solid #e5e5e5;
+}
+
+h1 {
+  margin: 0 0 8px;
+  font-size: 24px;
+}
+
+.subtitle {
+  margin: 0 0 24px;
+  color: #5b5b5b;
+}
+
+.toggle,
+.color-picker {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+  font-size: 16px;
+}
+
+.toggle input {
+  transform: scale(1.2);
+}
+
+.color-picker input {
+  width: 52px;
+  height: 32px;
+  border: none;
+  background: transparent;
+}
+
+.note {
+  margin-top: 24px;
+  font-size: 13px;
+  color: #7a7a7a;
+}

--- a/options.html
+++ b/options.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Slack Bracket Highlighter Options</title>
+    <link rel="stylesheet" href="options.css" />
+  </head>
+  <body>
+    <main class="options-card">
+      <h1>Slack Bracket Highlighter</h1>
+      <p class="subtitle">
+        Highlight text wrapped in full-width brackets (【...】) within the Slack
+        sidebar.
+      </p>
+
+      <label class="toggle">
+        <input type="checkbox" id="enabled" />
+        <span>Enable highlighting</span>
+      </label>
+
+      <label class="color-picker">
+        <span>Highlight color</span>
+        <input type="color" id="highlightColor" />
+      </label>
+
+      <p class="note">
+        Changes apply immediately to any open Slack tabs.
+      </p>
+    </main>
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,24 @@
+const DEFAULT_SETTINGS = {
+  enabled: true,
+  highlightColor: "#fff3a3"
+};
+
+const enabledInput = document.getElementById("enabled");
+const colorInput = document.getElementById("highlightColor");
+
+function applySettings(settings) {
+  enabledInput.checked = settings.enabled;
+  colorInput.value = settings.highlightColor;
+}
+
+function saveSettings() {
+  chrome.storage.sync.set({
+    enabled: enabledInput.checked,
+    highlightColor: colorInput.value
+  });
+}
+
+chrome.storage.sync.get(DEFAULT_SETTINGS, applySettings);
+
+enabledInput.addEventListener("change", saveSettings);
+colorInput.addEventListener("input", saveSettings);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,10 @@
+:root {
+  --slack-bracket-highlight-color: #fff3a3;
+}
+
+.slack-bracket-highlight {
+  background-color: var(--slack-bracket-highlight-color);
+  border-radius: 3px;
+  padding: 0 2px;
+  font-weight: 600;
+}


### PR DESCRIPTION
### Motivation
- Provide a small Proof-of-Concept Chrome extension that visually emphasizes text wrapped in full-width brackets `【...】` inside the Slack web client sidebar to validate feasibility and UX.
- Offer an easy-to-install local extension and basic settings so the behavior can be reviewed without touching Slack server-side data or tokens.

### Description
- Add a Manifest V3 extension manifest in `manifest.json` targeting `https://*.slack.com/*` with `storage` and host permissions and an `options_page` (`options.html`).
- Implement `contentScript.js` that scans sidebar text nodes, detects `【...】` patterns, wraps matches in a highlight `span` and keeps up with dynamic updates using a `MutationObserver` and configurable settings.
- Add styling in `styles.css` and an options UI (`options.html`, `options.css`, `options.js`) to toggle highlighting and choose the highlight color, with settings persisted to `chrome.storage.sync`.
- Update `README.md` with install instructions and notes for local testing and privacy considerations.

### Testing
- Launched a local static server with `python -m http.server 8000` and successfully rendered the options page, then captured an automated screenshot of `options.html` using Playwright which produced an artifact at `browser:/tmp/codex_browser_invocations/36d9bf0d9ccb862c/artifacts/artifacts/options.png`.
- No unit tests or CI were run as part of this PoC; manual/local install instructions are included in `README.md` for further validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979b9626d10833182683fae9c015736)